### PR TITLE
실행중인 태스크의 Actual duration이 일시적으로 초기화 되어 표시되는 버그 수정

### DIFF
--- a/views/web/jest.setup.ts
+++ b/views/web/jest.setup.ts
@@ -3,6 +3,8 @@ import { server } from './src/mock/server/test-server'
 import * as tasksDB from './src/mock/tasks'
 import { testQueryClient } from './src/utils/rtl-utils'
 
+jest.mock('./src/utils/timerWorker')
+
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'bypass' })
 })

--- a/views/web/src/screens/Home.tsx
+++ b/views/web/src/screens/Home.tsx
@@ -44,9 +44,7 @@ function Home() {
   const categories = useCategories()
 
   const createTask = useCreateTask()
-  const {
-    data: { tasks, activeTask }
-  } = useTasks(getPeriodToday())
+  const tasks = useTasks(getPeriodToday())
   const { mutate: deleteTask } = useDeleteTask()
   const {
     mutate: update,
@@ -56,10 +54,6 @@ function Home() {
   } = useUpdateTask()
 
   const [activeId, setActiveId] = useState<string>('')
-
-  useEffect(() => {
-    setActiveId(activeTask?.id ?? '')
-  }, [activeTask])
 
   const onSubmit = (data: CreateTaskDto) => {
     createTask.mutate({
@@ -112,6 +106,7 @@ function Home() {
 
       if (state === 'pause' || state === 'complete') {
         removeActiveTask()
+        setActiveId('')
       }
 
       resetUpdateState()

--- a/views/web/src/screens/Home.tsx
+++ b/views/web/src/screens/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Button,
   Empty,
@@ -14,16 +14,16 @@ import styled from 'styled-components'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
-  setQueryDataForTasks,
   useCreateTask,
   useDeleteTask,
   useTasks,
   useUpdateTask
 } from '../utils/query-tasks'
-import { getPeriodToday, useLocalStorageState } from '../utils/misc'
+import { getPeriodToday } from '../utils/misc'
 import { Task } from '@timespark/domain/models'
 import { useCategories } from '../utils/query-categories'
 import { setSequence } from '../utils/sequence'
+import { removeActiveTask, setActiveTask } from '../utils/timerWorker'
 
 const schema = z.object({
   categoryId: z.string(),
@@ -43,22 +43,23 @@ function Home() {
 
   const categories = useCategories()
 
-  const [activeTask, setActiveTask] = useLocalStorageState('activeTask', null)
-  const [timerId, setTimerId] = useLocalStorageState('timerId', 0)
-
   const createTask = useCreateTask()
-  const tasks = useTasks(getPeriodToday())
   const {
-    mutate: deleteTask,
-    isSuccess: deleteSuccess,
-    reset: resetDeleteState
-  } = useDeleteTask()
+    data: { tasks, activeTask }
+  } = useTasks(getPeriodToday())
+  const { mutate: deleteTask } = useDeleteTask()
   const {
     mutate: update,
     data: updatedTask,
     isSuccess: updateSuccess,
     reset: resetUpdateState
   } = useUpdateTask()
+
+  const [activeId, setActiveId] = useState<string>('')
+
+  useEffect(() => {
+    setActiveId(activeTask?.id ?? '')
+  }, [activeTask])
 
   const onSubmit = (data: CreateTaskDto) => {
     createTask.mutate({
@@ -73,13 +74,6 @@ function Home() {
     deleteTask({ id })
   }
 
-  useEffect(() => {
-    if (deleteSuccess) {
-      setActiveTask(null)
-      resetDeleteState()
-    }
-  }, [deleteSuccess, resetDeleteState, setActiveTask])
-
   const onStart = (id: string) => {
     const task = tasks?.find((task) => task.id === id)
     if (!task) return
@@ -92,13 +86,11 @@ function Home() {
   }
 
   const onPause = (id: string) => {
-    if (activeTask?.id === id) {
-      update({
-        id,
-        state: 'pause',
-        time: new Date().toISOString()
-      })
-    }
+    update({
+      id,
+      state: 'pause',
+      time: new Date().toISOString()
+    })
   }
 
   const onComplete = (id: string) => {
@@ -114,41 +106,17 @@ function Home() {
       const state = updatedTask.state
 
       if (state === 'start' || state === 'continue') {
-        let time = updatedTask.actualDuration
-        const id = setInterval(() => {
-          const newTask = {
-            ...updatedTask,
-            actualDuration: time + 1
-          }
-
-          setQueryDataForTasks(newTask)
-          setActiveTask(newTask)
-
-          time += 1
-        }, 1000)
-
-        setTimerId(id)
-        setActiveTask(updatedTask) // disable other tasks immediately
+        setActiveTask(updatedTask)
+        setActiveId(updatedTask.id)
       }
 
       if (state === 'pause' || state === 'complete') {
-        clearInterval(timerId)
-        setTimerId(0)
-        setActiveTask(null)
+        removeActiveTask()
       }
 
       resetUpdateState()
     }
-  }, [
-    activeTask,
-    setActiveTask,
-    resetUpdateState,
-    updateSuccess,
-    tasks,
-    setTimerId,
-    timerId,
-    updatedTask
-  ])
+  }, [resetUpdateState, updateSuccess, tasks, updatedTask])
 
   const onDrop = (tasks: Task[]) => {
     setSequence(tasks.map((task) => task.id))
@@ -198,7 +166,7 @@ function Home() {
             onStart={onStart}
             onPause={onPause}
             onComplete={onComplete}
-            activeTaskId={activeTask?.id ?? ''}
+            activeTaskId={activeId}
           />
         </TaskListContextProvider>
       ) : (

--- a/views/web/src/utils/__mocks__/timerWorker.ts
+++ b/views/web/src/utils/__mocks__/timerWorker.ts
@@ -1,0 +1,3 @@
+export const setActiveTask = jest.fn()
+export const getActiveTask = jest.fn()
+export const removeActiveTask = jest.fn()

--- a/views/web/src/utils/misc.tsx
+++ b/views/web/src/utils/misc.tsx
@@ -1,5 +1,4 @@
 import { format, parseISO, startOfToday, startOfTomorrow } from 'date-fns'
-import { useDebugValue, useEffect, useRef, useState } from 'react'
 
 /**
  * @returns ISO formatted date strings
@@ -26,41 +25,4 @@ const getPeriodToday = () => {
  */
 const formatDate = (date: string) => format(parseISO(date), 'yyyy.MM.dd HH:mm')
 
-/**
- * @param {String} key The key to set in localStorage for this value
- * @param {Object} defaultValue The value to use if it is not already in localStorage
- * @param {{serialize: Function, deserialize: Function}} options The serialize and deserialize functions to use (defaults to JSON.stringify and JSON.parse respectively)
- */
-function useLocalStorageState(
-  key: string,
-  defaultValue: string | number | null,
-  { serialize = JSON.stringify, deserialize = JSON.parse } = {}
-) {
-  const [state, setState] = useState(() => {
-    const valueInLocalStorage = window.localStorage.getItem(key)
-    if (valueInLocalStorage) {
-      return deserialize(valueInLocalStorage)
-    }
-    return defaultValue
-  })
-
-  useDebugValue(`${key}: ${serialize(state)}`)
-
-  const prevKeyRef = useRef(key)
-
-  useEffect(() => {
-    const prevKey = prevKeyRef.current
-    if (prevKey !== key) {
-      window.localStorage.removeItem(prevKey)
-    }
-    prevKeyRef.current = key
-  }, [key])
-
-  useEffect(() => {
-    window.localStorage.setItem(key, serialize(state))
-  }, [key, state, serialize])
-
-  return [state, setState]
-}
-
-export { getPeriodToday, formatDate, useLocalStorageState }
+export { getPeriodToday, formatDate }

--- a/views/web/src/utils/query-tasks.ts
+++ b/views/web/src/utils/query-tasks.ts
@@ -31,7 +31,7 @@ export const useCreateTask = () =>
   })
 
 export const useTasks = ({ from, to }: GetTasksDto) => {
-  const queryResult = useQuery({
+  const { data } = useQuery({
     queryKey: taskKeys.lists({ from, to }),
     queryFn: () => port.taskPort(adapter.taskRepository).getTasks({ from, to })
   })
@@ -39,8 +39,6 @@ export const useTasks = ({ from, to }: GetTasksDto) => {
   const [result, setResult] = useState<Task[]>([])
 
   useEffect(() => {
-    const data = queryResult.data
-
     if (!data) return
 
     getActiveTask()
@@ -67,9 +65,9 @@ export const useTasks = ({ from, to }: GetTasksDto) => {
 
     setResult(tempResult)
     setSequence(tempResult.map((task) => task.id))
-  }, [queryResult.data])
+  }, [data])
 
-  return { ...queryResult, data: { tasks: result, activeTask } }
+  return result
 }
 
 export const useDeleteTask = () =>

--- a/views/web/src/utils/query-tasks.ts
+++ b/views/web/src/utils/query-tasks.ts
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react'
 import { queryClient } from '../context'
 import { getPeriodToday } from './misc'
 import { getSequence, setSequence } from './sequence'
-import { requestActiveTask } from './timerWorker'
+import { getActiveTask } from './timerWorker'
 
 export const taskKeys = {
   all: ['tasks'] as const,
@@ -43,7 +43,7 @@ export const useTasks = ({ from, to }: GetTasksDto) => {
 
     if (!data) return
 
-    requestActiveTask()
+    getActiveTask()
 
     let tempResult: Task[] = []
 

--- a/views/web/src/utils/timerWorker.ts
+++ b/views/web/src/utils/timerWorker.ts
@@ -1,7 +1,7 @@
 import { Task } from '@timespark/domain/models'
 import TimerWorker from '../workers/timer.worker?worker'
 import {
-  setActiveTask as setCurrentActiveTask,
+  setActiveTask as setActiveTaskInMainThread,
   setQueryDataForTasks
 } from './query-tasks'
 
@@ -11,7 +11,7 @@ export const setActiveTask = (task: Task) => {
   timerWorker.postMessage({ action: 'set', data: task })
 }
 
-export const requestActiveTask = () => {
+export const getActiveTask = () => {
   timerWorker.postMessage({ action: 'get' })
 }
 
@@ -31,13 +31,13 @@ timerWorker.onmessage = (event: MessageEvent<string>) => {
 
   switch (action) {
     case 'getActiveTask':
-      setCurrentActiveTask(data)
+      setActiveTaskInMainThread(data)
       break
     case 'setActiveTask':
       setQueryDataForTasks(data)
       break
     case 'removeActiveTask':
-      setCurrentActiveTask(null)
+      setActiveTaskInMainThread(null)
       break
     default:
       return

--- a/views/web/src/utils/timerWorker.ts
+++ b/views/web/src/utils/timerWorker.ts
@@ -19,8 +19,15 @@ export const removeActiveTask = () => {
   timerWorker.postMessage({ action: 'remove' })
 }
 
+type TimerWorkerUtilType =
+  | {
+      action: 'getActiveTask' | 'setActiveTask'
+      data: Task
+    }
+  | { action: 'removeActiveTask'; data?: undefined }
+
 timerWorker.onmessage = (event: MessageEvent<string>) => {
-  const { action, data } = event.data
+  const { action, data } = event.data as unknown as TimerWorkerUtilType
 
   switch (action) {
     case 'getActiveTask':

--- a/views/web/src/utils/timerWorker.ts
+++ b/views/web/src/utils/timerWorker.ts
@@ -1,0 +1,38 @@
+import { Task } from '@timespark/domain/models'
+import TimerWorker from '../workers/timer.worker?worker'
+import {
+  setActiveTask as setCurrentActiveTask,
+  setQueryDataForTasks
+} from './query-tasks'
+
+const timerWorker = new TimerWorker()
+
+export const setActiveTask = (task: Task) => {
+  timerWorker.postMessage({ action: 'set', data: task })
+}
+
+export const requestActiveTask = () => {
+  timerWorker.postMessage({ action: 'get' })
+}
+
+export const removeActiveTask = () => {
+  timerWorker.postMessage({ action: 'remove' })
+}
+
+timerWorker.onmessage = (event: MessageEvent<string>) => {
+  const { action, data } = event.data
+
+  switch (action) {
+    case 'getActiveTask':
+      setCurrentActiveTask(data)
+      break
+    case 'setActiveTask':
+      setQueryDataForTasks(data)
+      break
+    case 'removeActiveTask':
+      setCurrentActiveTask(null)
+      break
+    default:
+      return
+  }
+}

--- a/views/web/src/workers/timer.worker.ts
+++ b/views/web/src/workers/timer.worker.ts
@@ -91,8 +91,18 @@ function remove() {
   }
 }
 
+type TimerWorkerType =
+  | {
+      action: 'get' | 'remove'
+      data?: undefined
+    }
+  | {
+      action: 'set'
+      data: Task
+    }
+
 self.onmessage = (event: MessageEvent<string>) => {
-  const { action, data } = event.data
+  const { action, data } = event.data as unknown as TimerWorkerType
 
   switch (action) {
     case 'get':

--- a/views/web/src/workers/timer.worker.ts
+++ b/views/web/src/workers/timer.worker.ts
@@ -8,7 +8,7 @@ let db: IDBDatabase
 
 let timerId: number
 
-DBOpenRequest.onupgradeneeded = function (event) {
+DBOpenRequest.onupgradeneeded = function () {
   console.log('[ObjectStore created]')
 
   db = DBOpenRequest.result
@@ -42,7 +42,7 @@ function set(task: Task) {
         timerId
       })
 
-    updateRequest.onsuccess = function (event) {
+    updateRequest.onsuccess = function () {
       self.postMessage({ action: 'setActiveTask', data: taskObj })
     }
 
@@ -62,7 +62,7 @@ function get() {
     .objectStore(storeName)
     .getAll()
 
-  getRequest.onsuccess = function (event) {
+  getRequest.onsuccess = function () {
     self.postMessage({
       action: 'getActiveTask',
       data: getRequest.result[0]

--- a/views/web/src/workers/timer.worker.ts
+++ b/views/web/src/workers/timer.worker.ts
@@ -1,0 +1,112 @@
+import { Task } from '@timespark/domain/models'
+
+const dbName = 'timeSpark'
+const storeName = 'activeTasks'
+
+const DBOpenRequest: IDBOpenDBRequest = indexedDB.open(dbName, 1)
+let db: IDBDatabase
+
+let timerId: number
+
+DBOpenRequest.onupgradeneeded = function (event) {
+  console.log('[ObjectStore created]')
+
+  db = DBOpenRequest.result
+  db.createObjectStore(storeName, { keyPath: 'id' })
+}
+
+DBOpenRequest.onsuccess = function (event) {
+  console.log('[Success opening database]', event)
+
+  db = DBOpenRequest.result
+}
+
+DBOpenRequest.onerror = function (event) {
+  console.log('[Error opening database]', event)
+}
+
+function set(task: Task) {
+  let time = task.actualDuration
+
+  const update = () => {
+    const taskObj = {
+      ...task,
+      actualDuration: time + 1
+    }
+
+    const updateRequest = db
+      .transaction(storeName, 'readwrite')
+      .objectStore(storeName)
+      .put({
+        ...taskObj,
+        timerId
+      })
+
+    updateRequest.onsuccess = function (event) {
+      self.postMessage({ action: 'setActiveTask', data: taskObj })
+    }
+
+    updateRequest.onerror = function (event) {
+      console.log('Error updating object:', event)
+    }
+
+    time += 1
+  }
+
+  timerId = setInterval(update, 1000)
+}
+
+function get() {
+  const getRequest = db
+    .transaction(storeName, 'readonly')
+    .objectStore(storeName)
+    .getAll()
+
+  getRequest.onsuccess = function (event) {
+    self.postMessage({
+      action: 'getActiveTask',
+      data: getRequest.result[0]
+    })
+  }
+
+  getRequest.onerror = function (event) {
+    console.log('[Error get object]', event)
+  }
+}
+
+function remove() {
+  clearInterval(timerId)
+
+  const clearRequest = db
+    .transaction(storeName, 'readwrite')
+    .objectStore(storeName)
+    .clear()
+
+  clearRequest.onsuccess = () => {
+    self.postMessage({ action: 'removeActiveTask' })
+  }
+
+  clearRequest.onerror = (event) => {
+    console.log('Error clearing object:', event)
+  }
+}
+
+self.onmessage = (event: MessageEvent<string>) => {
+  const { action, data } = event.data
+
+  switch (action) {
+    case 'get':
+      get()
+      break
+    case 'set':
+      set(data)
+      break
+    case 'remove':
+      remove()
+      break
+    default:
+      return
+  }
+}
+
+export {}


### PR DESCRIPTION
## 🔑 Key Changes

### 원인
1. 페이지 이동후 복귀시
- 홈화면을 벗어나는 순간 Home 컴포넌트가 언마운트됨 → useLocalStorageState 훅이 동작하지 않아 local storage에 실행중인 태스크 정보 및 타이머 ID 정보를 갱신할 수 없음
- 다시 홈화면으로 돌아왔을 때에는 useLocalStorageState 훅의 초기값인 null에 의해 초기화 된 것 처럼 표시됨

2. 태스크 추가시
- useLocalStorageState 훅의 초기값인 null에 의해 초기화 된 것 처럼 표시됨

### 해결
- Home 컴포넌트가 언마운트 되거나 태스크 추가 등으로 목록이 리렌더링 되더라도 항상 최신 상태의 실행중인 태스크 정보를 알 수 있어야 함
- Web Worker를 사용하여 타이머 기능을 애플리케이션의 백그라운드에서 실행하도록 변경
    - 실행중인 태스크 정보 및 타이머 아이디는 Indexed DB에 저장

<br />

## 🔗 Linked Issue

- #40 

<br />
