### PR TITLE
날짜가 변경된 이후 새롭게 생성한 태스크가 비활성화되어 표시되는 버그 수정

### DIFF
--- a/views/web/src/App.tsx
+++ b/views/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import Layout from './components/Layout'
 import { RequireAuth } from './context/auth-context'
@@ -6,6 +7,7 @@ import Dashboard from './screens/Dashboard'
 import FullPageError from './screens/FullPageError'
 import Home from './screens/Home'
 import Settings from './screens/Settings'
+import { removeActiveTask } from './utils/timerWorker'
 
 export const routeConfig = [
   {
@@ -40,6 +42,10 @@ export const routeConfig = [
 const router = createBrowserRouter(routeConfig)
 
 function App() {
+  useEffect(() => {
+    removeActiveTask()
+  }, [])
+
   return <RouterProvider router={router} />
 }
 


### PR DESCRIPTION
## 🔑 Key Changes

- 원인: IndexedDB에 이전 날짜에 생성된 activeTask 값이 남아있어 발생
- 해결:
    - 현재는 태스크 목록 데이터를 메모리상에 올려두고 있기 때문에 브라우저를 새로고침하여 App을 새로 로드하면 IndexedDB를 초기화하도록 함
    - API 개발시 상황별 activeTask 처리 Spec 정의 및 추가 개발 예정
        1. 앱을 새로고침 하는 경우
        2. 앱을 실행중인 상태에서 날짜가 바뀌는 경우

<br />

## 🔗 Linked Issue

- #40 

<br />
